### PR TITLE
Configure entity name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ $background_image = "";
 $custom_css = "css/dsfr/dsfr.css";
 ```
 
+Configure some messages:
+```php
+$messages['dsfr_entity_name'] = "Ministère<br>...<br>...";
+```
+
 ## Development
 
 To test the theme from current git repository, you will need:

--- a/templates/dsfr/footer.tpl
+++ b/templates/dsfr/footer.tpl
@@ -5,7 +5,7 @@
     <div class="fr-container">
         <div class="fr-footer__body">
             <div class="fr-footer__brand fr-enlarge-link">
-                <p class="fr-logo">Ministère<br>de l'agriculture<br>et de la souveraineté<br>alimentaire</p>
+                <p class="fr-logo">{$msg_dsfr_entity_name nofilter}</p>
             </div>
             <div class="fr-footer__content">
                 <div>LDAP Tool Box Self Service Password - version {$version}</div>

--- a/templates/dsfr/index.tpl
+++ b/templates/dsfr/index.tpl
@@ -7,7 +7,7 @@
                 <div class="fr-header__brand fr-enlarge-link">
                     <div class="fr-header__brand-top">
                         <div class="fr-header__logo">
-                            <p class="fr-logo">Ministère<br>de l'agriculture<br>et de la souveraineté<br>alimentaire</p>
+                            <p class="fr-logo">{$msg_dsfr_entity_name nofilter}</p>
                         </div>
                     </div>
                     <div class="fr-header__service">


### PR DESCRIPTION
The entity name can be configured with a message:
```php
$messages['dsfr_entity_name'] = "Ministère<br>...<br>...";
```